### PR TITLE
caplog: Handle disabled logging in 'set_level' and 'at_level' #8711

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Akiomi Kamakura
 Alan Velasco
 Alessio Izzo
 Alex Jones
+Alex Lambson
 Alexander Johnson
 Alexander King
 Alexei Kozlenok

--- a/changelog/8711.improvement.rst
+++ b/changelog/8711.improvement.rst
@@ -1,0 +1,3 @@
+:func:`_pytest.logging.LogCaptureFixture.set_level` and :func:`_pytest.logging.LogCaptureFixture.at_level`
+will temporarily enable the requested ``level`` if ``level`` was disabled globally via
+``logging.disable(LEVEL)``.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -49,7 +49,7 @@ from _pytest._code import ExceptionInfo
 from _pytest._code import filter_traceback
 from _pytest._io import TerminalWriter
 from _pytest.compat import final
-from _pytest.compat import importlib_metadata
+from _pytest.compat import importlib_metadata  # type: ignore[attr-defined]
 from _pytest.outcomes import fail
 from _pytest.outcomes import Skipped
 from _pytest.pathlib import absolutepath

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -463,7 +463,7 @@ class LogCaptureFixture:
     ) -> int:
         """Enable the desired logging level if the level was disabled.
 
-        Only enables logging levels equal too and higher than the requested ``level``.
+        Only enables logging levels greater than or equal to the requested ``level``.
 
         Does nothing if the desired ``level`` wasn't disabled.
 
@@ -478,16 +478,17 @@ class LogCaptureFixture:
         original_disable_level: int = logger_obj.manager.disable  # type: ignore[attr-defined]
 
         if isinstance(level, str):
+            # Try to translate the level string to an int for `logging.disable()`
             level = logging.getLevelName(level)
 
         if not isinstance(level, int):
+            # The level provided was not valid, so just un-disable all logging.
             logging.disable(logging.NOTSET)
-            return original_disable_level
-        if logger_obj.isEnabledFor(level):
-            return original_disable_level
-
-        disable_level = max(level - 10, logging.NOTSET)
-        logging.disable(disable_level)
+        elif not logger_obj.isEnabledFor(level):
+            # Each level is `10` away from other levels.
+            # https://docs.python.org/3/library/logging.html#logging-levels
+            disable_level = max(level - 10, logging.NOTSET)
+            logging.disable(disable_level)
 
         return original_disable_level
 

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -376,11 +376,12 @@ class LogCaptureFixture:
         self._initial_handler_level: Optional[int] = None
         # Dict of log name -> log level.
         self._initial_logger_levels: Dict[Optional[str], int] = {}
+        self._initial_disabled_logging_level: Optional[int] = None
 
     def _finalize(self) -> None:
         """Finalize the fixture.
 
-        This restores the log levels changed by :meth:`set_level`.
+        This restores the log levels and the disabled logging levels changed by :meth:`set_level`.
         """
         # Restore log levels.
         if self._initial_handler_level is not None:
@@ -388,6 +389,10 @@ class LogCaptureFixture:
         for logger_name, level in self._initial_logger_levels.items():
             logger = logging.getLogger(logger_name)
             logger.setLevel(level)
+        # Disable logging at the original disabled logging level.
+        if self._initial_disabled_logging_level is not None:
+            logging.disable(self._initial_disabled_logging_level)
+            self._initial_disabled_logging_level = None
 
     @property
     def handler(self) -> LogCaptureHandler:
@@ -453,12 +458,47 @@ class LogCaptureFixture:
         """Reset the list of log records and the captured log text."""
         self.handler.clear()
 
+    def force_enable_logging(
+        self, level: Union[int, str], logger_obj: logging.Logger
+    ) -> int:
+        """Enable the desired logging level if the level was disabled.
+
+        Only enables logging levels equal too and higher than the requested ``level``.
+
+        Does nothing if the desired ``level`` wasn't disabled.
+
+        :param Union[int, str] level:
+            The logger level caplog should capture.
+            All logging is enabled if a non-standard logging level string is supplied.
+            Valid level strings are in :data:`logging._nameToLevel`.
+        :param Logger logger_obj: The logger object to check.
+
+        :return int: The original disabled logging level.
+        """
+        original_disable_level: int = logger_obj.manager.disable  # type: ignore[attr-defined]
+
+        if isinstance(level, str):
+            level = logging.getLevelName(level)
+
+        if not isinstance(level, int):
+            logging.disable(logging.NOTSET)
+            return original_disable_level
+        if logger_obj.isEnabledFor(level):
+            return original_disable_level
+
+        disable_level = max(level - 10, logging.NOTSET)
+        logging.disable(disable_level)
+
+        return original_disable_level
+
     def set_level(self, level: Union[int, str], logger: Optional[str] = None) -> None:
         """Set the level of a logger for the duration of a test.
 
         .. versionchanged:: 3.4
             The levels of the loggers changed by this function will be
             restored to their initial values at the end of the test.
+
+        Will enable the requested logging level if it was disabled via :meth:`logging.disable`.
 
         :param level: The level.
         :param logger: The logger to update. If not given, the root logger.
@@ -470,6 +510,9 @@ class LogCaptureFixture:
         if self._initial_handler_level is None:
             self._initial_handler_level = self.handler.level
         self.handler.setLevel(level)
+        initial_disabled_logging_level = self.force_enable_logging(level, logger_obj)
+        if self._initial_disabled_logging_level is None:
+            self._initial_disabled_logging_level = initial_disabled_logging_level
 
     @contextmanager
     def at_level(
@@ -479,6 +522,8 @@ class LogCaptureFixture:
         the end of the 'with' statement the level is restored to its original
         value.
 
+        Will enable the requested logging level if it was disabled via :meth:`logging.disable`.
+
         :param level: The level.
         :param logger: The logger to update. If not given, the root logger.
         """
@@ -487,11 +532,13 @@ class LogCaptureFixture:
         logger_obj.setLevel(level)
         handler_orig_level = self.handler.level
         self.handler.setLevel(level)
+        original_disable_level = self.force_enable_logging(level, logger_obj)
         try:
             yield
         finally:
             logger_obj.setLevel(orig_level)
             self.handler.setLevel(handler_orig_level)
+            logging.disable(original_disable_level)
 
 
 @fixture

--- a/src/_pytest/logging.py
+++ b/src/_pytest/logging.py
@@ -458,22 +458,22 @@ class LogCaptureFixture:
         """Reset the list of log records and the captured log text."""
         self.handler.clear()
 
-    def force_enable_logging(
+    def _force_enable_logging(
         self, level: Union[int, str], logger_obj: logging.Logger
     ) -> int:
-        """Enable the desired logging level if the level was disabled.
+        """Enable the desired logging level if the global level was disabled via ``logging.disabled``.
 
         Only enables logging levels greater than or equal to the requested ``level``.
 
         Does nothing if the desired ``level`` wasn't disabled.
 
-        :param Union[int, str] level:
+        :param level:
             The logger level caplog should capture.
             All logging is enabled if a non-standard logging level string is supplied.
             Valid level strings are in :data:`logging._nameToLevel`.
-        :param Logger logger_obj: The logger object to check.
+        :param logger_obj: The logger object to check.
 
-        :return int: The original disabled logging level.
+        :return: The original disabled logging level.
         """
         original_disable_level: int = logger_obj.manager.disable  # type: ignore[attr-defined]
 
@@ -511,7 +511,7 @@ class LogCaptureFixture:
         if self._initial_handler_level is None:
             self._initial_handler_level = self.handler.level
         self.handler.setLevel(level)
-        initial_disabled_logging_level = self.force_enable_logging(level, logger_obj)
+        initial_disabled_logging_level = self._force_enable_logging(level, logger_obj)
         if self._initial_disabled_logging_level is None:
             self._initial_disabled_logging_level = initial_disabled_logging_level
 
@@ -533,7 +533,7 @@ class LogCaptureFixture:
         logger_obj.setLevel(level)
         handler_orig_level = self.handler.level
         self.handler.setLevel(level)
-        original_disable_level = self.force_enable_logging(level, logger_obj)
+        original_disable_level = self._force_enable_logging(level, logger_obj)
         try:
             yield
         finally:

--- a/testing/logging/test_fixture.py
+++ b/testing/logging/test_fixture.py
@@ -1,4 +1,4 @@
-# type: ignore[attr-defined]
+# mypy: disable-error-code="attr-defined"
 import logging
 
 import pytest
@@ -88,7 +88,7 @@ def test_change_level_undo(pytester: Pytester) -> None:
 def test_change_disabled_level_undo(
     pytester: Pytester, cleanup_disabled_logging
 ) -> None:
-    """Ensure that 'force_enable_logging' in 'set_level' is undone after the end of the test.
+    """Ensure that '_force_enable_logging' in 'set_level' is undone after the end of the test.
 
     Tests the logging output themselves (affected by disabled logging level).
     """
@@ -200,7 +200,7 @@ def test_with_statement_logging_disabled(caplog, cleanup_disabled_logging):
 def test_force_enable_logging_level_string(
     caplog, cleanup_disabled_logging, level_str, expected_disable_level
 ):
-    """Test force_enable_logging using a level string.
+    """Test _force_enable_logging using a level string.
 
     ``expected_disable_level`` is one level below ``level_str`` because the disabled log level
     always needs to be *at least* one level lower than the level that caplog is trying to capture.
@@ -211,7 +211,7 @@ def test_force_enable_logging_level_string(
     # Make sure all logging is disabled.
     assert not test_logger.isEnabledFor(logging.CRITICAL)
     # Un-disable logging for `level_str`.
-    caplog.force_enable_logging(level_str, test_logger)
+    caplog._force_enable_logging(level_str, test_logger)
     # Make sure that the disabled level is now one below the requested logging level.
     # We don't use `isEnabledFor` here because that also checks the level set by
     # `logging.setLevel()` which is irrelevant to `logging.disable()`.


### PR DESCRIPTION
Forces requested `caplog` logging levels to be enabled if they were disabled via `logging.disable()`

`[attr-defined]` mypy error ignored in `logging.py` because there were existing errors with the imports
and `loggin.Logger.manager` is an attr set at runtime. Since it's in the standard lib I can't really fix that.

Ignored an attr-defined error in `src/_pytest/config/__init__.py` because the re-export is necessary.

Closes #8711

<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [X] Include documentation when adding new features.
- [X] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

If this change fixes an issue, please:

- [X] Add text like ``closes #XYZW`` to the PR description and/or commits (where ``XYZW`` is the issue number). See the [github docs](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more information.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [X] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/main/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [X] Add yourself to `AUTHORS` in alphabetical order.
-->
